### PR TITLE
Add missing body-parser dependency to node package list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Ben Burrus",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.16.0",
     "express": "^4.14.0",
     "mongodb": "^2.2.21"
   },


### PR DESCRIPTION
The repository includes the node_modules folder, but in case of incompatibility I deleted it and did an 'npm install'. When I started the app it failed because body-parser was missing. Adding it to the package.json file fixed that.